### PR TITLE
Small Improvements

### DIFF
--- a/src/commons.py
+++ b/src/commons.py
@@ -98,3 +98,25 @@ def load_repositories(organization: str, tabs: list[TabSettings], max_workers: i
         _ = [execution.result() for execution in executions]
 
     return selected_repos
+
+
+def reload_settings(settings: Settings, repos: dict[str, Repository]):
+    """Reload repositories into settings object.
+
+    Parameters
+    ----------
+    settings : Settings
+        The settings object to be reloaded.
+
+    repos : dict[str, Repository]
+        Repositories to be reloaded into the settings object.
+
+    """
+    for tab in settings.tabs:
+        for group in tab.groups:
+            group.repositories = sorted([
+                repo.name for repo in filter(
+                    lambda repo: set(group.topics).issubset(set(repo.topics)),
+                    repos.values(),
+                )
+            ])

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,6 @@ from streamlit.delta_generator import DeltaGenerator
 from src.models.settings import (
     GroupSettings,
     TabSettings,
-    Settings,
 )
 from src.models.repository import (
     Repository,
@@ -18,6 +17,7 @@ from src.commons import (
     column_ratio_is_valid,
     load_settings,
     load_repositories,
+    reload_settings,
 )
 from src.styles import (
     CENTER_HEADER,
@@ -29,12 +29,6 @@ DASHBOARD_SETTINGS_FILE = getenv("DASHBOARD_SETTINGS_FILE", "settings.json")
 DASHBOARD_REPOSITORY_HEADER = getenv("DASHBOARD_REPOSITORY_HEADER", "Repository")
 DASHBOARD_REPOSITORY_EMOJI = getenv("DASHBOARD_REPOSITORY_EMOJI", "gear")
 DASHBOARD_MAX_WORKERS = int(getenv("DASHBOARD_MAX_WORKERS", 4))
-
-
-@st.cache_resource
-def get_settings(path: str) -> Settings:
-    """Load the settings from a JSON file."""
-    return load_settings(path)
 
 
 @st.cache_data(ttl=60 * 60 * 1, show_spinner=True)
@@ -95,7 +89,7 @@ st.markdown("""
     </style>
 """, unsafe_allow_html=True)
 
-SETTINGS = get_settings(DASHBOARD_SETTINGS_FILE)
+SETTINGS = load_settings(DASHBOARD_SETTINGS_FILE)
 
 st.title("GitHub Deployments")
 
@@ -104,6 +98,11 @@ if len(SETTINGS.tabs) == 0:
     st.stop()
 
 DASHBOARD_REPOS = get_repositories(SETTINGS.organization, SETTINGS.tabs, DASHBOARD_MAX_WORKERS)
+
+# When refreshed inside the cache TTL time, the app will not load the repositories
+# for each group in the settings object. This code checks if the repositories are
+# loaded and, if not, it will load them again.
+reload_settings(SETTINGS, DASHBOARD_REPOS)
 
 st_tabs = [st.container()] if len(SETTINGS.tabs) == 1 else st.tabs([tab.title for tab in SETTINGS.tabs])
 


### PR DESCRIPTION
- When it's one tab/group, use a container to hide the header
- Remove settings from the cache to give more flexibility when configuring the dashboard.