### PR TITLE
Raise exception if Github token is empty or not provided

### DIFF
--- a/src/tools/github_api.py
+++ b/src/tools/github_api.py
@@ -40,6 +40,9 @@ def call_github_endpoint(
     extra: dict[str, Any] = {}
     endpoint = "https://api.github.com/"
 
+    if len(DASHBOARD_GITHUB_TOKEN) == 0:
+        raise SystemError("No Github token provided. Please set the environment variable: DASHBOARD_GITHUB_TOKEN")
+
     args = {
         "url": endpoint + path,
         "headers": {


### PR DESCRIPTION
If no GitHub token is given, trigger an exception so the user can understand faster why the app did not correctly start.